### PR TITLE
feat: public user-now access is used from storage to autologin

### DIFF
--- a/src/contexts/auth/index.tsx
+++ b/src/contexts/auth/index.tsx
@@ -16,6 +16,7 @@ export interface AuthContextData {
   Logout(): void;
   isLoading: boolean;
   isError: boolean;
+  access: string | null;
   Access: (accessCode: string) => Promise<void>;
   Reset(): void;
 }
@@ -26,6 +27,7 @@ const axios = new AxiosAdapter();
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<IUserData | null>(null);
+  const [access, setAccessCode] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
 
@@ -57,6 +59,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       .access(accessCode)
       .then((access: PublicUser) => {
         setIsError(false);
+        setAccessCode(access.code);
         localStorage.setItem('@Wodful:access', access.code);
         localStorage.setItem('@Wodful:pcname', access.championship.name);
       })
@@ -65,6 +68,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   }, []);
 
   const Reset = useCallback(() => {
+    setAccessCode(null);
     localStorage.removeItem('@Wodful:access');
     localStorage.removeItem('@Wodful:pcname');
   }, []);
@@ -72,7 +76,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   useEffect(() => {
     const storagedUser = localStorage.getItem('@Wodful:usr');
     const storagedToken = localStorage.getItem('@Wodful:tkn');
+    const storagedCode = localStorage.getItem('@Wodful:access');
 
+    if (storagedCode) setAccessCode(storagedCode);
     if (storagedToken && storagedUser) {
       setUser(JSON.parse(storagedUser));
     }
@@ -80,7 +86,17 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   return (
     <AuthContext.Provider
-      value={{ signed: Boolean(user), user, Login, Logout, isLoading, isError, Access, Reset }}
+      value={{
+        signed: Boolean(user),
+        user,
+        Login,
+        Logout,
+        isLoading,
+        isError,
+        Access,
+        Reset,
+        access,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/pages/public/Access/index.tsx
+++ b/src/pages/public/Access/index.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 const Access = () => {
-  const { Access, isError, isLoading } = useAuth();
+  const { Access, isError, isLoading, access } = useAuth();
   const [accessCode, setAccessCode] = useState('');
   const navigate = useNavigate();
   const location = useLocation();
@@ -38,8 +38,9 @@ const Access = () => {
   const isEmpty = useMemo(() => !accessCode.length, [accessCode]);
 
   useEffect(() => {
+    if (access) navigate(`/access/${access}/leaderboards`);
     AnalyticsAdapter.pageview(location.pathname);
-  }, [location.pathname]);
+  }, [location.pathname, access]);
 
   return (
     <Box>


### PR DESCRIPTION
Now the user that already put the access code will have that information saved on localstorage, and on re-opening the page will get that information and automatically navigate to leaderboard page
![#146](https://github.com/EXtreme-go-horse-club/wodful-web/assets/79146964/37b2399c-3181-4536-b7cb-0651faa807fc)
